### PR TITLE
Explicitly return user so function operates as expected when user is found

### DIFF
--- a/lib/redmine_env_auth/env_auth_patch.rb
+++ b/lib/redmine_env_auth/env_auth_patch.rb
@@ -80,6 +80,7 @@ module RedmineEnvAuth
               user.language = Setting.default_language
               if user.save
                 user.reload
+                return user
               else
                 logger.error "redmine_env_auth: user creation after ldap sync failed"
                 nil


### PR DESCRIPTION
I've found that users aren't automatically logged in with this plugin and they have to explicitly click "sign in" at the top right corner my Redmine instance. Users are not prompted for a password from Redmine (provided they have already authorized with the SSO solution), but they are not automatically signed in the first time they visit the site.

Reviewing the redmine_env_auth code I found the register_if_exists_in_ldap function in lib/redmine_env_auth/env_auth_patch.rb is expected to return a user object, but given my (extremely limited) understanding of Ruby the code does not appear to be doing so without the patch I've created.

I've tested this change with several users on a fresh Redmine install with my branch of this plugin in a test environment and it appears to be all good.