### PR TITLE
Rails 5 support

### DIFF
--- a/app/controllers/env_auth_controller.rb
+++ b/app/controllers/env_auth_controller.rb
@@ -1,6 +1,9 @@
 class EnvAuthController < ApplicationController
   include EnvAuthHelper
-  skip_before_filter :user_setup, :check_if_login_required
+
+  skip_method = self.respond_to?(:skip_before_filter) ? :skip_before_filter : :skip_before_action
+
+  send(skip_method, :user_setup, :check_if_login_required)
   helper :env_auth
 
   def info


### PR DESCRIPTION
- backwards compatible
- Use `#prepend` instead of `#alias_method_chain` 
https://blog.bigbinary.com/2016/08/21/rails-5-deprecates-alias-method-chain.html
- Use `#skip_before_action` instead of `#skip_before_filter`

Tested with:

```
Environment:
  Redmine version                4.0.0.devel
  Ruby version                   2.4.5-p335 (2018-10-18) [amd64-freebsd11]
  Rails version                  5.2.2
```