### PR TITLE
adds envvar registration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = spcace

--- a/app/controllers/env_auth_controller.rb
+++ b/app/controllers/env_auth_controller.rb
@@ -9,9 +9,18 @@ class EnvAuthController < ApplicationController
     text = [
       "variable name: #{variable_name}",
       "original value: #{original.inspect}",
-      "effective value: #{effective.inspect}",
-      "available variables:\n  #{keys}"
+      "effective value: #{effective.inspect}"
     ].join("\n")
+
+    text = "#{text}\navailable variables:\n  #{keys}"
     render :plain => text
+  end
+
+  def logout
+    if Setting.plugin_redmine_env_auth["external_logout_target"] == ""
+      redirect_to signout_path
+    else 
+      redirect_to Setting.plugin_redmine_env_auth["external_logout_target"]
+    end
   end
 end

--- a/app/views/settings/_redmine_env_auth_settings.html.erb
+++ b/app/views/settings/_redmine_env_auth_settings.html.erb
@@ -40,3 +40,27 @@
   <%= content_tag(:label, l(:label_ldap_checked_auto_registration))%>
   <%= check_box_tag "settings[ldap_checked_auto_registration]", true, @settings["ldap_checked_auto_registration"] == "true" %>
 </p>
+
+<p>
+  <%= content_tag(:label, l(:label_env_checked_auto_registration))%>
+  <%= check_box_tag "settings[env_checked_auto_registration]", true, @settings["env_checked_auto_registration"] == "true" %><br/>
+  <%= content_tag(:label, l(:label_env_variable_firstname)) %>
+  <%= text_field_tag "settings[env_variable_firstname]", @settings["env_variable_firstname"] %><br/>
+  <%= l(:label_default)%>: GIVENNAME<br/>
+  <%= content_tag(:label, l(:label_env_variable_lastname)) %>
+  <%= text_field_tag "settings[env_variable_lastname]", @settings["env_variable_lastname"] %><br/>
+  <%= l(:label_default)%>: LASTNAME<br/>
+  <%= content_tag(:label, l(:label_env_variable_email)) %>
+  <%= text_field_tag "settings[env_variable_email]", @settings["env_variable_email"] %><br/>
+  <%= l(:label_default)%>: EMAIL<br/>
+  <%= content_tag(:label, l(:label_env_variable_admins)) %>
+  <%= text_field_tag "settings[env_variable_admins]", @settings["env_variable_admins"] %><br/>
+  <%= l(:label_env_variable_admins_description)%><br/>
+  <%= content_tag(:label, l(:label_env_variable_new_user_initial_locked))%>
+  <%= check_box_tag "settings[env_variable_new_user_initial_locked]", true, @settings["env_variable_new_user_initial_locked"] == "true" %><br/>
+  <%= content_tag(:label, l(:label_show_logout_link))%>
+  <%= check_box_tag "settings[show_logout_link]", true, @settings["show_logout_link"] == "true" %><br/>
+  <%= content_tag(:label, l(:label_external_logout_target)) %>
+  <%= text_field_tag "settings[external_logout_target]", @settings["external_logout_target"] %><br/>
+  <%= l(:label_external_logout_target_description)%><br/>
+</p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,3 +13,13 @@ de:
   label_remove_suffix_help: Der eingetragene Text wird vom Ende des Texts in der Umgebungsvariable abgeschnitten
   label_remove_suffix: Entferne suffix
   label_redmine_user_property: Redmine Benutzereigenschaft
+  label_env_checked_auto_registration: Auto-Registrierung mit Umgebungsvariablen
+  label_env_variable_firstname: Variable mit Vorname
+  label_env_variable_lastname: Variable mit Nachname
+  label_env_variable_email: Variable mit Email-Adresse
+  label_env_variable_admins: Liste mit Admin-Logins
+  label_env_variable_admins_description: Kommaseparierte Liste mit Logins, die als Administratoren registriert werden
+  label_env_variable_new_user_initial_locked: Sperre neu registrierte Konten
+  label_show_logout_link: Abmelden-Link anzeigen
+  label_external_logout_target:  Ziel für Abmelden-Link
+  label_external_logout_target_description: hier kann ein externer Abmeldeservice angegeben werden. Wenn leer, Umleitung auf internen logout-Pfad

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,13 @@ en:
   label_remove_suffix_help: the given text will be removed from the end of the text in the environment variable
   label_remove_suffix: remove suffix
   label_redmine_user_property: redmine user property
+  label_env_checked_auto_registration: automatic registration with env variables
+  label_env_variable_firstname: variable with firstname
+  label_env_variable_lastname: variable with lastname
+  label_env_variable_email: variable with email
+  label_env_variable_admins: list of admin logins
+  label_env_variable_admins_description: comma separated list of login that will be registered as admins
+  label_env_variable_new_user_initial_locked: lock newly registered accounts
+  label_show_logout_link: display logout link
+  label_external_logout_target:  where to redirect on logout
+  label_external_logout_target_description: specify an external logout service. if empty the internal logout path is used

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 RedmineApp::Application.routes.draw do
   get "env_auth/info", :to => "env_auth#info"
+  get 'env_auth/logout', :to => "env_auth#logout"
 end

--- a/init.rb
+++ b/init.rb
@@ -8,9 +8,16 @@ Redmine::Plugin.register :redmine_env_auth do
   Redmine::MenuManager.map :account_menu do |menu|
     # hide the logout link if an automatic login is active
     menu.delete :logout
-    menu.push :logout, :signout_path, :html => {:method => "post"}, :if => Proc.new {
-      env_auth_disabled = Setting.plugin_redmine_env_auth["enabled"] != "true"
-      User.current.logged? and env_auth_disabled
+    menu.push :logout, {:controller => 'env_auth', :action => 'logout'}, :caption => :label_logout, :if => Proc.new {
+      if !User.current.logged?
+        false
+      elsif Setting.plugin_redmine_env_auth["enabled"] != "true"
+        true
+      elsif Setting.plugin_redmine_env_auth["show_logout_link"] == "true"
+        true
+      else
+        false
+      end
     }, :after => :my_account
   end
 
@@ -22,7 +29,15 @@ Redmine::Plugin.register :redmine_env_auth do
       "env_variable_name" => "REMOTE_USER",
       "ldap_checked_auto_registration" => "false",
       "redmine_user_property" => "login",
-      "remove_suffix" => ""
+      "remove_suffix" => "",
+      "env_checked_auto_registration" => "false",
+      "env_variable_firstname" => "GIVENNAME",
+      "env_variable_lastname" => "LASTNAME",
+      "env_variable_email" => "EMAIL",
+      "env_variable_admins" => "",
+      "env_variable_new_user_initial_locked" => "false",
+      "show_logout_link" => "false",
+      "external_logout_target" => ""
     }
 end
 


### PR DESCRIPTION
Hi,

here are some modifications to enable this plugin to register a new user by provided env vars. basically three additional variables have to be filled with firstname, lastname and email so a user can be created. If specified, all new users are blocked by default, so manual interaction is necessary to activate a new user. Also there is a textfield for admin logins where a new user gets the admin-flag if its login appears in the list. Finally there is an option to display the logout-link again and an optional target url to a logout-service.

The behavior is totally optional and should not collide with the current functionality.

My use case is redmine behind a shibboleth-proxy to enable shibboleth-auth. The existing saml-plugin is unfortunately unusable.

This is the first time i code ruby and the first time i code redmine, so please be patient. If you find this changes useful i would like to enhance the code and documentation according to your suggestions.

cheers