### PR TITLE
Ability : external authentication

### DIFF
--- a/app/controllers/env_auth_controller.rb
+++ b/app/controllers/env_auth_controller.rb
@@ -23,4 +23,37 @@ class EnvAuthController < ApplicationController
       redirect_to Setting.plugin_redmine_env_auth["external_logout_target"]
     end
   end
+
+  def callback
+    if User.current.logged?
+      back_url = params[:back_url]
+      if back_url.present?
+        # Accepter les URLs relatives ou les URLs absolues du même hôte
+        if back_url.start_with?('/')
+          redirect_to back_url
+        else
+          begin
+            uri = URI.parse(back_url)
+            # Vérifier que c'est le même hôte que la requête actuelle
+            if uri.host == request.host
+              relative_url = uri.path.presence || '/'
+              relative_url += "?#{uri.query}" if uri.query.present?
+              redirect_to relative_url
+            else
+              logger.warn "redmine_env_auth: back_url host mismatch (#{uri.host} vs #{request.host})"
+              redirect_to home_path
+            end
+          rescue URI::InvalidURIError
+            logger.warn "redmine_env_auth: invalid back_url: #{back_url}"
+            redirect_to home_path
+          end
+        end
+      else
+        redirect_to home_path
+      end
+    else
+      flash[:error] = l(:notice_account_invalid_credentials)
+      redirect_to signin_path
+    end
+  end
 end

--- a/app/views/hooks/redmine_env_auth/_login_buttons.html.erb
+++ b/app/views/hooks/redmine_env_auth/_login_buttons.html.erb
@@ -1,0 +1,44 @@
+<%
+  settings = Setting.plugin_redmine_env_auth
+  auth_buttons = []
+  (1..5).each do |i|
+    url = settings["auth_url_#{i}"]
+    label = settings["auth_button_#{i}"]
+    if url.present? && label.present?
+      auth_buttons << { url: url, label: label }
+    end
+  end
+  allow_local_login = settings["allow_local_login"] != "false"
+%>
+
+<% if auth_buttons.any? %>
+<div id="env-auth-buttons" style="margin-top: 20px; text-align: center;">
+  <hr style="margin: 20px 0;"/>
+  
+  <div style="display: flex; flex-direction: column; gap: 10px; align-items: center;">
+    <% auth_buttons.each do |btn| %>
+    	<%= link_to btn[:label], btn[:url], :class => "button env-auth-button", :style => "display: inline-block; padding: 10px 20px; min-width: 200px; text-align: center; background-color: #628db6; color: white; text-decoration: none; border-radius: 4px;" %>
+    <% end %>
+    <% if allow_local_login %>
+	<p style="margin-bottom: 15px; color: #666;">
+		<%= l(:label_or_login_with) %>
+		<a href="#" onclick="document.getElementById('login-form').style.display='block'; document.getElementById('env-auth-buttons').style.display='none'; return false;" class="button" style="font-size: 0.9em;">
+        	<%= l(:label_local_account) %>
+      	</a>
+	</p>
+    <% end %>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var loginForm = document.getElementById('login-form');
+  var authButtons = document.getElementById('env-auth-buttons');
+  
+  if (loginForm && authButtons) {
+    // Masquer le formulaire de login par défaut et afficher les boutons
+    loginForm.style.display = 'none';
+  }
+});
+</script>
+<% end %>

--- a/app/views/hooks/redmine_env_auth/_login_buttons.html.erb
+++ b/app/views/hooks/redmine_env_auth/_login_buttons.html.erb
@@ -5,14 +5,24 @@
     url = settings["auth_url_#{i}"]
     label = settings["auth_button_#{i}"]
     if url.present? && label.present?
-      auth_buttons << { url: url, label: label }
+      auth_url = url
+      if params[:back_url].present?
+        separator = url.include?('?') ? '&' : '?'
+        auth_url = "#{url}#{separator}back_url=#{ERB::Util.url_encode(params[:back_url])}"
+      end
+      auth_buttons << { url: auth_url, label: label }
     end
   end
   allow_local_login = settings["allow_local_login"] != "false"
 %>
 
 <% if auth_buttons.any? %>
-<div id="env-auth-buttons" style="margin-top: 20px; text-align: center;">
+<style>
+  .env-auth-show { }
+  .env-auth-hide { display: none; }
+</style>
+
+<div id="env-auth-buttons" class="env-auth-show" style="margin-top: 20px; text-align: center;">
   <hr style="margin: 20px 0;"/>
   
   <div style="display: flex; flex-direction: column; gap: 10px; align-items: center;">
@@ -22,7 +32,7 @@
     <% if allow_local_login %>
 	<p style="margin-bottom: 15px; color: #666;">
 		<%= l(:label_or_login_with) %>
-		<a href="#" onclick="document.getElementById('login-form').style.display='block'; document.getElementById('env-auth-buttons').style.display='none'; return false;" class="button" style="font-size: 0.9em;">
+		<a href="#" onclick="envAuthShowLocalLogin(); return false;" class="button" style="font-size: 0.9em;">
         	<%= l(:label_local_account) %>
       	</a>
 	</p>
@@ -31,13 +41,25 @@
 </div>
 
 <script>
+function envAuthShowLocalLogin() {
+  var loginForm = document.getElementById('login-form');
+  var authButtons = document.getElementById('env-auth-buttons');
+  
+  if (loginForm && authButtons) {
+    loginForm.classList.remove('env-auth-hide');
+    loginForm.classList.add('env-auth-show');
+    authButtons.classList.remove('env-auth-show');
+    authButtons.classList.add('env-auth-hide');
+  }
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   var loginForm = document.getElementById('login-form');
   var authButtons = document.getElementById('env-auth-buttons');
   
   if (loginForm && authButtons) {
     // Masquer le formulaire de login par défaut et afficher les boutons
-    loginForm.style.display = 'none';
+    loginForm.classList.add('env-auth-hide');
   }
 });
 </script>

--- a/app/views/settings/_redmine_env_auth_settings.html.erb
+++ b/app/views/settings/_redmine_env_auth_settings.html.erb
@@ -64,3 +64,25 @@
   <%= text_field_tag "settings[external_logout_target]", @settings["external_logout_target"] %><br/>
   <%= l(:label_external_logout_target_description)%><br/>
 </p>
+
+<fieldset>
+  <legend><%= l(:label_external_auth_buttons) %></legend>
+  <p><%= l(:label_external_auth_buttons_description) %></p>
+  
+  <p>
+    <%= hidden_field_tag "settings[allow_local_login]", "false" %>
+    <%= check_box_tag "settings[allow_local_login]", "true", @settings["allow_local_login"] != "false" %>
+    <%= content_tag(:label, l(:label_allow_local_login)) %><br/>
+    <small><%= l(:label_allow_local_login_description) %></small>
+  </p>
+  
+  <% (1..5).each do |i| %>
+    <div style="margin-bottom: 10px; padding: 5px; border: 1px solid #ddd; border-radius: 4px;">
+      <strong><%= l(:label_auth_button_pair, :num => i) %></strong><br/>
+      <%= content_tag(:label, l(:label_auth_url)) %>
+      <%= text_field_tag "settings[auth_url_#{i}]", @settings["auth_url_#{i}"], :size => 50, :placeholder => "https://example.com/shibboleth/login" %><br/>
+      <%= content_tag(:label, l(:label_auth_button_label)) %>
+      <%= text_field_tag "settings[auth_button_#{i}]", @settings["auth_button_#{i}"], :size => 30, :placeholder => l(:label_auth_button_placeholder) %><br/>
+    </div>
+  <% end %>
+</fieldset>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -23,3 +23,13 @@ de:
   label_show_logout_link: Abmelden-Link anzeigen
   label_external_logout_target:  Ziel für Abmelden-Link
   label_external_logout_target_description: hier kann ein externer Abmeldeservice angegeben werden. Wenn leer, Umleitung auf internen logout-Pfad
+  label_external_auth_buttons: Externe Authentifizierungsschaltflächen
+  label_external_auth_buttons_description: Konfigurieren Sie externe Authentifizierungs-URLs und die entsprechenden Schaltflächenbeschriftungen. Leer lassen zum Deaktivieren.
+  label_auth_button_pair: Schaltfläche %{num}
+  label_auth_url: Authentifizierungs-URL
+  label_auth_button_label: Schaltflächenbeschriftung
+  label_auth_button_placeholder: z.B. Shibboleth-Anmeldung
+  label_or_login_with: "Oder anmelden mit einem "
+  label_local_account: lokalen Konto
+  label_allow_local_login: Lokale Anmeldung erlauben
+  label_allow_local_login_description: "Wenn deaktiviert, wird der Link 'lokales Konto' auf der Anmeldeseite nicht angezeigt"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,13 @@ en:
   label_show_logout_link: display logout link
   label_external_logout_target:  where to redirect on logout
   label_external_logout_target_description: specify an external logout service. if empty the internal logout path is used
+  label_external_auth_buttons: External Authentication Buttons
+  label_external_auth_buttons_description: Configure external authentication URLs and their corresponding button labels. Leave empty to disable.
+  label_auth_button_pair: Button %{num}
+  label_auth_url: Authentication URL
+  label_auth_button_label: Button label
+  label_auth_button_placeholder: e.g. Shibboleth Login
+  label_or_login_with: "Or login with a "
+  label_local_account: local account
+  label_allow_local_login: Allow local login
+  label_allow_local_login_description: "If unchecked, the 'local account' link will not be displayed on the login page"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,35 @@
+fr:
+  label_allow_other_login_admins: tous les administrateurs
+  label_allow_other_login_all: tous les utilisateurs
+  label_allow_other_login: autoriser la connexion standard
+  label_allow_other_login_none: désactivé
+  label_allow_other_login_users: certains utilisateurs (séparés par des virgules)
+  label_default: par défaut
+  label_email_address: adresse email
+  label_enabled: activer
+  label_env_variable_name: nom de la variable d'environnement de requête
+  label_ldap_checked_auto_registration: inscription automatique avec vérification LDAP
+  label_login_name: identifiant
+  label_remove_suffix_help: le texte indiqué sera supprimé de la fin de la valeur de la variable d'environnement
+  label_remove_suffix: supprimer le suffixe
+  label_redmine_user_property: propriété utilisateur Redmine
+  label_env_checked_auto_registration: inscription automatique avec variables d'environnement
+  label_env_variable_firstname: variable avec le prénom
+  label_env_variable_lastname: variable avec le nom
+  label_env_variable_email: variable avec l'email
+  label_env_variable_admins: liste des identifiants administrateurs
+  label_env_variable_admins_description: liste des identifiants séparés par des virgules qui seront inscrits comme administrateurs
+  label_env_variable_new_user_initial_locked: verrouiller les comptes nouvellement inscrits
+  label_show_logout_link: afficher le lien de déconnexion
+  label_external_logout_target: où rediriger lors de la déconnexion
+  label_external_logout_target_description: spécifiez un service de déconnexion externe. Si vide, le chemin de déconnexion interne est utilisé
+  label_external_auth_buttons: Boutons d'authentification externe
+  label_external_auth_buttons_description: Configurez les URLs d'authentification externe et les libellés des boutons correspondants. Laissez vide pour désactiver.
+  label_auth_button_pair: Bouton %{num}
+  label_auth_url: URL d'authentification
+  label_auth_button_label: Libellé du bouton
+  label_auth_button_placeholder: ex. Connexion Shibboleth
+  label_or_login_with: "Ou se connecter avec un "
+  label_local_account: compte local
+  label_allow_local_login: Autoriser la connexion locale
+  label_allow_local_login_description: "Si décoché, le lien 'compte local' ne sera pas affiché sur la page de connexion"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,0 +1,35 @@
+hu:
+  label_allow_other_login_admins: minden adminisztrátor
+  label_allow_other_login_all: minden felhasználó
+  label_allow_other_login: normál bejelentkezés engedélyezése
+  label_allow_other_login_none: letiltva
+  label_allow_other_login_users: egyes felhasználók (vesszővel elválasztva)
+  label_default: alapértelmezett
+  label_email_address: e-mail cím
+  label_enabled: engedélyezés
+  label_env_variable_name: kérés környezeti változó neve
+  label_ldap_checked_auto_registration: automatikus regisztráció LDAP ellenőrzéssel
+  label_login_name: bejelentkezési név
+  label_remove_suffix_help: a megadott szöveg eltávolításra kerül a környezeti változó szövegének végéről
+  label_remove_suffix: utótag eltávolítása
+  label_redmine_user_property: Redmine felhasználói tulajdonság
+  label_env_checked_auto_registration: automatikus regisztráció környezeti változókkal
+  label_env_variable_firstname: keresztnév változója
+  label_env_variable_lastname: vezetéknév változója
+  label_env_variable_email: e-mail változója
+  label_env_variable_admins: adminisztrátor bejelentkezések listája
+  label_env_variable_admins_description: vesszővel elválasztott bejelentkezések listája, amelyek adminisztrátorként lesznek regisztrálva
+  label_env_variable_new_user_initial_locked: újonnan regisztrált fiókok zárolása
+  label_show_logout_link: kijelentkezési link megjelenítése
+  label_external_logout_target: hová irányítson kijelentkezéskor
+  label_external_logout_target_description: adjon meg egy külső kijelentkezési szolgáltatást. Ha üres, a belső kijelentkezési útvonal kerül felhasználásra
+  label_external_auth_buttons: Külső hitelesítési gombok
+  label_external_auth_buttons_description: Konfigurálja a külső hitelesítési URL-eket és a hozzájuk tartozó gombcímkéket. Hagyja üresen a letiltáshoz.
+  label_auth_button_pair: Gomb %{num}
+  label_auth_url: Hitelesítési URL
+  label_auth_button_label: Gomb címke
+  label_auth_button_placeholder: pl. Shibboleth bejelentkezés
+  label_or_login_with: "Vagy jelentkezzen be "
+  label_local_account: helyi fiókkal
+  label_allow_local_login: Helyi bejelentkezés engedélyezése
+  label_allow_local_login_description: "Ha nincs bejelölve, a 'helyi fiók' link nem jelenik meg a bejelentkezési oldalon"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,3 +24,13 @@ ja:
   label_show_logout_link: ログアウトリンクを表示
   label_external_logout_target: ログアウト時のリダイレクト先
   label_external_logout_target_description: 外部ログアウトサービスを指定します。空の場合、内部のログアウトパスが使用されます。
+  label_external_auth_buttons: 外部認証ボタン
+  label_external_auth_buttons_description: 外部認証URLとそれに対応するボタンラベルを設定します。無効にするには空のままにしてください。
+  label_auth_button_pair: ボタン %{num}
+  label_auth_url: 認証URL
+  label_auth_button_label: ボタンラベル
+  label_auth_button_placeholder: "例: Shibbolethログイン"
+  label_or_login_with: "または"
+  label_local_account: ローカルアカウントでログイン
+  label_allow_local_login: ローカルログインを許可
+  label_allow_local_login_description: "チェックを外すと、ログインページに'ローカルアカウント'リンクが表示されません"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,35 @@
+pt-BR:
+  label_allow_other_login_admins: todos os administradores
+  label_allow_other_login_all: todos os usuários
+  label_allow_other_login: permitir login padrão
+  label_allow_other_login_none: desabilitado
+  label_allow_other_login_users: alguns usuários (separados por vírgula)
+  label_default: padrão
+  label_email_address: endereço de e-mail
+  label_enabled: habilitar
+  label_env_variable_name: nome da variável de ambiente de requisição
+  label_ldap_checked_auto_registration: registro automático com verificação LDAP
+  label_login_name: nome de login
+  label_remove_suffix_help: o texto informado será removido do final do texto na variável de ambiente
+  label_remove_suffix: remover sufixo
+  label_redmine_user_property: propriedade de usuário do Redmine
+  label_env_checked_auto_registration: registro automático com variáveis de ambiente
+  label_env_variable_firstname: variável com primeiro nome
+  label_env_variable_lastname: variável com sobrenome
+  label_env_variable_email: variável com e-mail
+  label_env_variable_admins: lista de logins de administradores
+  label_env_variable_admins_description: lista separada por vírgulas de logins que serão registrados como administradores
+  label_env_variable_new_user_initial_locked: bloquear contas recém-registradas
+  label_show_logout_link: exibir link de logout
+  label_external_logout_target: para onde redirecionar no logout
+  label_external_logout_target_description: especifique um serviço de logout externo. Se vazio, o caminho de logout interno é usado
+  label_external_auth_buttons: Botões de autenticação externa
+  label_external_auth_buttons_description: Configure URLs de autenticação externa e seus rótulos de botão correspondentes. Deixe vazio para desabilitar.
+  label_auth_button_pair: Botão %{num}
+  label_auth_url: URL de autenticação
+  label_auth_button_label: Rótulo do botão
+  label_auth_button_placeholder: ex. Login Shibboleth
+  label_or_login_with: "Ou faça login com uma "
+  label_local_account: conta local
+  label_allow_local_login: Permitir login local
+  label_allow_local_login_description: "Se desmarcado, o link 'conta local' não será exibido na página de login"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,35 @@
+ru:
+  label_allow_other_login_admins: все администраторы
+  label_allow_other_login_all: все пользователи
+  label_allow_other_login: разрешить стандартный вход
+  label_allow_other_login_none: отключено
+  label_allow_other_login_users: некоторые пользователи (через запятую)
+  label_default: по умолчанию
+  label_email_address: адрес электронной почты
+  label_enabled: включить
+  label_env_variable_name: имя переменной окружения запроса
+  label_ldap_checked_auto_registration: автоматическая регистрация с проверкой LDAP
+  label_login_name: имя пользователя
+  label_remove_suffix_help: указанный текст будет удален с конца текста в переменной окружения
+  label_remove_suffix: удалить суффикс
+  label_redmine_user_property: свойство пользователя Redmine
+  label_env_checked_auto_registration: автоматическая регистрация с переменными окружения
+  label_env_variable_firstname: переменная с именем
+  label_env_variable_lastname: переменная с фамилией
+  label_env_variable_email: переменная с email
+  label_env_variable_admins: список логинов администраторов
+  label_env_variable_admins_description: список логинов через запятую, которые будут зарегистрированы как администраторы
+  label_env_variable_new_user_initial_locked: блокировать новые зарегистрированные аккаунты
+  label_show_logout_link: показывать ссылку выхода
+  label_external_logout_target: куда перенаправлять при выходе
+  label_external_logout_target_description: укажите внешний сервис выхода. Если пусто, используется внутренний путь выхода
+  label_external_auth_buttons: Кнопки внешней аутентификации
+  label_external_auth_buttons_description: Настройте URL-адреса внешней аутентификации и соответствующие надписи на кнопках. Оставьте пустым для отключения.
+  label_auth_button_pair: Кнопка %{num}
+  label_auth_url: URL аутентификации
+  label_auth_button_label: Надпись на кнопке
+  label_auth_button_placeholder: напр. Вход Shibboleth
+  label_or_login_with: "Или войти с "
+  label_local_account: локальным аккаунтом
+  label_allow_local_login: Разрешить локальный вход
+  label_allow_local_login_description: "Если снято, ссылка 'локальный аккаунт' не будет отображаться на странице входа"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -23,3 +23,13 @@ zh:
   label_show_logout_link: 显示登出链接
   label_external_logout_target: 登出时重定向的位置
   label_external_logout_target_description: 指定一个外部登出服务。如果为空，将使用内部登出路径
+  label_external_auth_buttons: 外部认证按钮
+  label_external_auth_buttons_description: 配置外部认证URL及其对应的按钮标签。留空以禁用。
+  label_auth_button_pair: 按钮 %{num}
+  label_auth_url: 认证URL
+  label_auth_button_label: 按钮标签
+  label_auth_button_placeholder: 例如 Shibboleth登录
+  label_or_login_with: "或使用"
+  label_local_account: 本地账户登录
+  label_allow_local_login: 允许本地登录
+  label_allow_local_login_description: "如果取消勾选，登录页面将不显示'本地账户'链接"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 RedmineApp::Application.routes.draw do
   get "env_auth/info", :to => "env_auth#info"
   get 'env_auth/logout', :to => "env_auth#logout"
+  get 'env_auth/callback', :to => "env_auth#callback"
 end

--- a/init.rb
+++ b/init.rb
@@ -3,7 +3,7 @@ Redmine::Plugin.register :redmine_env_auth do
   author "Intera GmbH"
   url "http://github.com/intera/redmine_env_auth" if respond_to?(:url)
   description "A plugin for authentication based on variables in the request environment."
-  version "1.4"
+  version "1.4.3"
 
   Redmine::MenuManager.map :account_menu do |menu|
     # hide the logout link if an automatic login is active

--- a/init.rb
+++ b/init.rb
@@ -3,7 +3,7 @@ Redmine::Plugin.register :redmine_env_auth do
   author "Intera GmbH"
   url "http://github.com/intera/redmine_env_auth" if respond_to?(:url)
   description "A plugin for authentication based on variables in the request environment."
-  version "1.3"
+  version "1.4"
 
   Redmine::MenuManager.map :account_menu do |menu|
     # hide the logout link if an automatic login is active
@@ -37,14 +37,27 @@ Redmine::Plugin.register :redmine_env_auth do
       "env_variable_admins" => "",
       "env_variable_new_user_initial_locked" => "false",
       "show_logout_link" => "false",
-      "external_logout_target" => ""
+      "external_logout_target" => "",
+      "auth_url_1" => "",
+      "auth_button_1" => "",
+      "auth_url_2" => "",
+      "auth_button_2" => "",
+      "auth_url_3" => "",
+      "auth_button_3" => "",
+      "auth_url_4" => "",
+      "auth_button_4" => "",
+      "auth_url_5" => "",
+      "auth_button_5" => "",
+      "allow_local_login" => "true"
     }
 end
 
 if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
   RedmineEnvAuth::EnvAuthPatch.install
+  require_relative 'lib/redmine_env_auth/hooks'
 else
   Rails.configuration.to_prepare do
     RedmineEnvAuth::EnvAuthPatch.install
   end
+  require_relative 'lib/redmine_env_auth/hooks'
 end

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,25 +1,18 @@
-de:
-  label_allow_other_login_admins: Für Administratoren
-  label_allow_other_login_all: Für alle Benutzer
-  label_allow_other_login_none: Deaktiviert
-  label_allow_other_login: Standardlogin erlauben
-  label_allow_other_login_users: Für bestimmte Benutzer (Kommagetrennt)
-  label_default: Vorgabe
-  label_email_address: E-Mail-Adresse
-  label_enabled: Plugin verwenden
-  label_env_variable_name: Name der Umgebungsvariable für die Benutzerdaten
-  label_ldap_checked_auto_registration: Automatische Registrierung mit LDAP-Abgleich
-  label_login_name: Loginname
-  label_remove_suffix_help: Der eingetragene Text wird vom Ende des Texts in der Umgebungsvariable abgeschnitten
-  label_remove_suffix: Entferne suffix
-  label_redmine_user_property: Redmine Benutzereigenschaft
-  label_env_checked_auto_registration: Auto-Registrierung mit Umgebungsvariablen
-  label_env_variable_firstname: Variable mit Vorname
-  label_env_variable_lastname: Variable mit Nachname
-  label_env_variable_email: Variable mit Email-Adresse
-  label_env_variable_admins: Liste mit Admin-Logins
-  label_env_variable_admins_description: Kommaseparierte Liste mit Logins, die als Administratoren registriert werden
-  label_env_variable_new_user_initial_locked: Sperre neu registrierte Konten
-  label_show_logout_link: Abmelden-Link anzeigen
-  label_external_logout_target:  Ziel für Abmelden-Link
-  label_external_logout_target_description: hier kann ein externer Abmeldeservice angegeben werden. Wenn leer, Umleitung auf internen logout-Pfad
+# German strings
+label_enable_env_auth: ENV Authentifizierung aktivieren
+label_server_env_var: Name für die Umgebungsvariable des Server
+label_default: Standard
+label_lookup_mode: Lokaler Lookup Modus
+label_login_name: Login Name
+label_email_address: Email Addresse
+login_envauth_title: via ENV-Authentifizierung einloggen
+label_enable_auto_registration: Automatische  Registrierung
+label_autoregister: Registrierung
+error_autoregistration_disabled: Automatische  Registrierung ist deaktiviert
+error_remote_user_unset: Benutzername wurde nicht angegeben
+error_unknown_user: Benutzer konnte nicht gefunden werden
+label_keep_sessions: Verbindung aufrecht erhalten nachdem die ENV Authentifizierung abgelaufen ist (sicherheitskritisch und nicht empfohlen!)
+label_external_auth_buttons: Externe Authentifizierungsschaltflächen
+label_or_login_with: "Oder anmelden mit einem "
+label_local_account: lokalen Konto
+label_allow_local_login: Lokale Anmeldung erlauben

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,25 +1,18 @@
-en:
-  label_allow_other_login_admins: all admininstrators
-  label_allow_other_login_all: all users
-  label_allow_other_login: allow standard login
-  label_allow_other_login_none: disabled
-  label_allow_other_login_users: some users (comma separated)
-  label_default: default
-  label_email_address: email address
-  label_enabled: enable
-  label_env_variable_name: name of request environment variable
-  label_ldap_checked_auto_registration: automatic registration with ldap check
-  label_login_name: login name
-  label_remove_suffix_help: the given text will be removed from the end of the text in the environment variable
-  label_remove_suffix: remove suffix
-  label_redmine_user_property: redmine user property
-  label_env_checked_auto_registration: automatic registration with env variables
-  label_env_variable_firstname: variable with firstname
-  label_env_variable_lastname: variable with lastname
-  label_env_variable_email: variable with email
-  label_env_variable_admins: list of admin logins
-  label_env_variable_admins_description: comma separated list of login that will be registered as admins
-  label_env_variable_new_user_initial_locked: lock newly registered accounts
-  label_show_logout_link: display logout link
-  label_external_logout_target:  where to redirect on logout
-  label_external_logout_target_description: specify an external logout service. if empty the internal logout path is used
+# english strings
+label_enable_env_auth: enable env authentication
+label_server_env_var: name of server environment variable
+label_default: default
+label_lookup_mode: local user lookup mode
+label_login_name: login name
+label_email_address: email address
+login_envauth_title: sign in via env-auth
+label_enable_auto_registration: automatic registration
+label_autoregister: registration
+error_autoregistration_disabled: automatic registration is disabled
+error_remote_user_unset: username is not provided
+error_unknown_user: user was not found in the database
+label_keep_sessions: keep redmine sessions open after env authentication lost (dangerous!)
+label_external_auth_buttons: External Authentication Buttons
+label_or_login_with: "Or login with a "
+label_local_account: local account
+label_allow_local_login: Allow local login

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -1,0 +1,18 @@
+# French strings
+label_enable_env_auth: Activer l'authentification ENV
+label_server_env_var: Nom de la variable d'environnement serveur
+label_default: défaut
+label_lookup_mode: Mode de recherche de l'utilisateur
+label_login_name: nom d'utilisateur
+label_email_address: adresse e-mail
+login_envauth_title: Connexion via ENV-Auth
+label_enable_auto_registration: Création de compte automatique
+label_autoregister: Création de compte
+error_autoregistration_disabled: La création de comtpe automatique est désactivée
+error_remote_user_unset: Le nom d'utilisateur n'a pas été fourni
+error_unknown_user: L'utilisateur n'a pas été trouvé dans la base de données
+label_keep_sessions: Garder les sessions Redmine ouvertes même après la perte de l'authentification ENV (dangereux !)
+label_external_auth_buttons: Boutons d'authentification externe
+label_or_login_with: "Ou se connecter avec un "
+label_local_account: compte local
+label_allow_local_login: Autoriser la connexion locale

--- a/lang/hu.yml
+++ b/lang/hu.yml
@@ -1,0 +1,18 @@
+# Magyar fordítások
+label_enable_env_auth: ENV autentikáció engedélyezése
+label_server_env_var: Beléptetésre felhasznált környezeti változó
+label_default: alapértelmezett
+label_lookup_mode: Helyi felhasználó megkeresése
+label_login_name: felhasználónév alapján
+label_email_address: e-mail cím alapján
+login_envauth_title: Bejelentkezés ENV-Auth-tal
+label_enable_auto_registration: Automatikus regisztráció
+label_autoregister: Regisztráció
+error_autoregistration_disabled: Az automatikus regisztráció nincs engedélyezve
+error_remote_user_unset: A felhasználónév nem elérhető
+error_unknown_user: A felhasználó nem található az adatbázisban
+label_keep_sessions: Redmine munkamenet megtartása a ENV authentikációs információ megszűnése után (veszélyes!)
+label_external_auth_buttons: Külső hitelesítési gombok
+label_or_login_with: "Vagy jelentkezzen be "
+label_local_account: helyi fiókkal
+label_allow_local_login: Helyi bejelentkezés engedélyezése

--- a/lang/ja.yml
+++ b/lang/ja.yml
@@ -1,26 +1,18 @@
-# Japanese translation by Akiko Takano, tohosaku
-ja:
-  label_allow_other_login_admins: 全てのシステム管理者
-  label_allow_other_login_all: 全てのユーザー
-  label_allow_other_login: 通常のログインを許可
-  label_allow_other_login_none: 許可しない
-  label_allow_other_login_users: 指定されたユーザーのみ (カンマ区切り)
-  label_default: デフォルト
-  label_email_address: メールアドレス
-  label_enabled: 有効にする
-  label_env_variable_name: サーバの環境変数名
-  label_ldap_checked_auto_registration: LDAPの確認に基づく自動登録
-  label_login_name: ログイン名
-  label_remove_suffix_help: 入力された文字列は、環境変数の末尾から削除されます。
-  label_remove_suffix: 削除するサフィックス
-  label_redmine_user_property: 対応するredmine 側のユーザー情報
-  label_env_checked_auto_registration: 環境変数による自動登録
-  label_env_variable_firstname: 名の変数
-  label_env_variable_lastname: 姓の変数
-  label_env_variable_email: メールの変数
-  label_env_variable_admins: 管理者ログインのリスト
-  label_env_variable_admins_description: 管理者として登録されるログインのカンマ区切りリスト
-  label_env_variable_new_user_initial_locked: 新規登録アカウントをロック
-  label_show_logout_link: ログアウトリンクを表示
-  label_external_logout_target: ログアウト時のリダイレクト先
-  label_external_logout_target_description: 外部ログアウトサービスを指定します。空の場合、内部のログアウトパスが使用されます。
+# Japanese translation by Akiko Takano
+label_enable_env_auth: ENV認証を有効にする
+label_server_env_var: サーバの環境変数名
+label_default: デフォルト
+label_lookup_mode: ローカルユーザの検索モード
+label_login_name: ログイン名
+label_email_address: メールアドレス
+login_envauth_title: ENV認証でログイン
+label_enable_auto_registration: 自動登録
+label_autoregister: 登録
+error_autoregistration_disabled: 自動登録を無効にする
+error_remote_user_unset: ユーザ名が設定されていません
+error_unknown_user: データベースに該当するユーザが存在しません
+label_keep_sessions: ENV認証が切れたあともRedmineのセッションを継続させる (危険です!)
+label_external_auth_buttons: 外部認証ボタン
+label_or_login_with: "または"
+label_local_account: ローカルアカウントでログイン
+label_allow_local_login: ローカルログインを許可

--- a/lang/pt-br.yml
+++ b/lang/pt-br.yml
@@ -1,0 +1,18 @@
+# Brazilian Portuguese strings
+label_enable_env_auth: Habilitar Autenticação ENV
+label_server_env_var: Nome da variável de ambiente
+label_default: padrão
+label_lookup_mode: Modo de validação local de usuário
+label_login_name: login
+label_email_address: endereço de e-mail
+login_envauth_title: Autenticação via ENV
+label_enable_auto_registration: Registro automático
+label_autoregister: Registro
+error_autoregistration_disabled: Registro automático está desabilitado
+error_remote_user_unset: Nome de usuário não informado
+error_unknown_user: Usuário não encontrado na base de usuários
+label_keep_sessions: Manter sessões do redmine ativas após a perda da autenticação ENV (Muito perigoso)
+label_external_auth_buttons: Botões de autenticação externa
+label_or_login_with: "Ou faça login com uma "
+label_local_account: conta local
+label_allow_local_login: Permitir login local

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -1,0 +1,18 @@
+# Russian strings
+label_enable_env_auth: Включить ENV Authentication
+label_server_env_var: Имя серверной переменной окружения
+label_default: по умолчанию
+label_lookup_mode: Способ поиска пользователя
+label_login_name: имя пользователя
+label_email_address: адрес электронной почты
+login_envauth_title: Входить через ENV-Auth
+label_enable_auto_registration: Автоматическая регистрация
+label_autoregister: Регистрация
+error_autoregistration_disabled: Автоматическая регистрация отключена
+error_remote_user_unset: Имя пользователя не указано
+error_unknown_user: Пользователь не найден в базе данных
+label_keep_sessions: Оставлять сессии redmine открытыми после потери ENV authentication (опасно!)
+label_external_auth_buttons: Кнопки внешней аутентификации
+label_or_login_with: "Или войти с "
+label_local_account: локальным аккаунтом
+label_allow_local_login: Разрешить локальный вход

--- a/lang/zh.yml
+++ b/lang/zh.yml
@@ -1,25 +1,18 @@
-zh:
-  label_allow_other_login_admins: 所有管理员
-  label_allow_other_login_all: 所有用户
-  label_allow_other_login: 允许标准登录
-  label_allow_other_login_none: 已禁用
-  label_allow_other_login_users: 一些用户（以逗号分隔）
-  label_default: 默认
-  label_email_address: 电子邮件地址
-  label_enabled: 启用
-  label_env_variable_name: 请求环境变量的名称
-  label_ldap_checked_auto_registration: 带有LDAP检查的自动注册
-  label_login_name: 登录名
-  label_remove_suffix_help: 将从环境变量文本的末尾移除给定的文本
-  label_remove_suffix: 移除后缀
-  label_redmine_user_property: Redmine用户属性
-  label_env_checked_auto_registration: 使用环境变量的自动注册
-  label_env_variable_firstname: 名字的变量
-  label_env_variable_lastname: 姓氏的变量
-  label_env_variable_email: 邮箱的变量
-  label_env_variable_admins: 管理员登录列表
-  label_env_variable_admins_description: 以逗号分隔的登录列表，这些登录将被注册为管理员
-  label_env_variable_new_user_initial_locked: 锁定新注册的账户
-  label_show_logout_link: 显示登出链接
-  label_external_logout_target: 登出时重定向的位置
-  label_external_logout_target_description: 指定一个外部登出服务。如果为空，将使用内部登出路径
+# Chinese strings
+label_enable_env_auth: 启用ENV认证
+label_server_env_var: 服务器环境变量名称
+label_default: 默认
+label_lookup_mode: 本地用户查找模式
+label_login_name: 登录名
+label_email_address: 电子邮件地址
+login_envauth_title: 通过ENV认证登录
+label_enable_auto_registration: 自动注册
+label_autoregister: 注册
+error_autoregistration_disabled: 自动注册已禁用
+error_remote_user_unset: 未提供用户名
+error_unknown_user: 在数据库中未找到用户
+label_keep_sessions: 在ENV认证丢失后保持Redmine会话开启（危险！）
+label_external_auth_buttons: 外部认证按钮
+label_or_login_with: "或使用"
+label_local_account: 本地账户登录
+label_allow_local_login: 允许本地登录

--- a/lib/redmine_env_auth/hooks.rb
+++ b/lib/redmine_env_auth/hooks.rb
@@ -1,0 +1,6 @@
+module RedmineEnvAuth
+  class Hooks < Redmine::Hook::ViewListener
+    # Hook pour afficher les boutons d'authentification externe sur la page de login
+    render_on :view_account_login_bottom, :partial => 'hooks/redmine_env_auth/login_buttons'
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,12 @@ this plugin allows to authenticate users using a variable in the request environ
 * automatically log-in users if a specific request environment variable is set, and log-out if it is unset
 * option to allow conventional redmine logins for admins, specific users or everyone
 * option to register users automatically if they are found using ldap
-* option to register users automatically from additional environment variables
 * "sign out" link hidden when autologin is active
 * compatible with redmine 4
 
 # installation
 ## download
-dowload a [release](https://github.com/Intera/redmine_env_auth/tags) or a [zip file](https://github.com/Intera/redmine_env_auth/archive/master.zip) via github and unpack the archive.
+dowload a [release](https://github.com/Intera/redmine_env_auth/releases) or a [zip file](https://github.com/Intera/redmine_env_auth/archive/master.zip) via github and unpack the archive.
 alternatively you can clone the repository with "git clone https://github.com/Intera/redmine_env_auth.git"
 
 ## setup
@@ -59,24 +58,15 @@ RequestHeader set X_REMOTE_USER expr=%{REMOTE_USER}
 
 if you are locked out because the allow other login setting is not set to "all" and the request environment variable isnt set correctly, you might want to reset the plugin settings to be able to log-in with the conventional redmine login. the plugin settings are stored in the database and the sql to delete them is ``delete from settings where name="plugin_redmine_env_auth";``. you might have to restart redmine afterwards
 
-# environment auto registration
-users can also be registered based on environment variables, with options for initial account locking, admin assignment, and custom logout services.
-
-## settings
-* enable
-* environment variable name for the first name
-* environment variable name for the last name
-* environment variable name for the email
-* comma-separated list of admin logins
-* lock newly registered accounts
-* display a logout link
-* url for an external logout service
-
 # possible enhancements
 * document how passing the login variable to only specific url paths can work
 * automated tests
 
 # changelog
+* 2026-01-15: 
+  * ability to add buttons and URLs for external authentication
+  * ability to deny login via a local account
+  * French translation
 * 2024-11-21: quick test with redmine 6
 * 2018-08: completely revised, less code, added debugging features
 


### PR DESCRIPTION
What the PR does :

- ability to add buttons and URLs for external authentication
- ability to deny login via a local account
- French translation

Context : 
I needed Shibboleth authentication, but I didn't want the entire Redmine system to be constrained by a Shibboleth session.
These changes allow me to manage Shibboleth authentication on the `/auth/Shibboleth` URL, for example, and add a button on the login page that links to this page. Once the user has authenticated, he is redirected to Redmine and the plugin retrieves the necessary variables as usual.

Redmine 6.x needed